### PR TITLE
Added check to avoid errors with no initializers.

### DIFF
--- a/snippets/core/boot.js
+++ b/snippets/core/boot.js
@@ -47,7 +47,7 @@ boot = function(dependencies) {
   app = angular.module("{@= app_name @}", deps);
   mapHash = {};
   injectorDependencies = ["{@= app_name @}"];
-  if (Object.keys(initializers).length > 0 && typeof initializers[".."] !== "undefined" && typeof initializers[".."].app !== "undefined") {
+  if (initializers !== undefined && Object.keys(initializers).length > 0 && typeof initializers[".."] !== "undefined" && typeof initializers[".."].app !== "undefined") {
     resolvesList = initializers[".."].app.initializers;
     objectKeys = Object.keys(resolvesList);
     x = 0;


### PR DESCRIPTION
I noticed that I had an error in chrome when loading a blank project from the default template and having no initializers. Adding this trivial change should allow things to work properly.